### PR TITLE
고급매핑- mappedSuperClass

### DIFF
--- a/src/main/java/com/project/jpaproject/domain/order/BaseEntity.java
+++ b/src/main/java/com/project/jpaproject/domain/order/BaseEntity.java
@@ -1,0 +1,20 @@
+package com.project.jpaproject.domain.order;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@MappedSuperclass
+public class BaseEntity {
+
+    @Column(name = "created_by")
+    private String createdBy;
+
+    @Column(name = "created_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/project/jpaproject/domain/order/Item.java
+++ b/src/main/java/com/project/jpaproject/domain/order/Item.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "DTYPE")
 @Table(name = "item")
-public abstract class Item {
+public abstract class Item extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)

--- a/src/main/java/com/project/jpaproject/domain/order/Member.java
+++ b/src/main/java/com/project/jpaproject/domain/order/Member.java
@@ -11,7 +11,7 @@ import java.util.List;
 @Table(name = "member")
 @Getter
 @Setter
-public class Member {
+public class Member extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE)
     private Long id;

--- a/src/main/java/com/project/jpaproject/domain/order/Order.java
+++ b/src/main/java/com/project/jpaproject/domain/order/Order.java
@@ -14,7 +14,7 @@ import java.util.Objects;
 @Table(name = "orders")
 @Getter
 @Setter
-public class Order {
+public class Order extends BaseEntity{
 
     @Id
     @Column(name = "id")

--- a/src/main/java/com/project/jpaproject/domain/order/OrderItem.java
+++ b/src/main/java/com/project/jpaproject/domain/order/OrderItem.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 @Table(name = "order_item")
 @Getter
 @Setter
-public class OrderItem {
+public class OrderItem extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,8 +10,7 @@ spring:
   jpa:
     generate-ddl: true
     hibernate:
-      hbm2ddl:
-        auto: create-drop
+      ddl-auto: create-drop
     database: mysql
     show-sql: true
     open-in-view: false

--- a/src/test/java/com/project/jpaproject/domain/order/ImproveMappingTest.java
+++ b/src/test/java/com/project/jpaproject/domain/order/ImproveMappingTest.java
@@ -9,6 +9,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.time.LocalDateTime;
+import java.util.UUID;
+
 @Slf4j
 @SpringBootTest
 public class ImproveMappingTest {
@@ -33,6 +36,29 @@ public class ImproveMappingTest {
         entityManager.persist(food);
 
         transaction.commit();
+    }
+
+    @Test
+    @DisplayName("mapped_super_class Test")
+    void mapped_super_class_test(){
+        EntityManager entityManager = emf.createEntityManager();
+        EntityTransaction transaction = entityManager.getTransaction();
+
+        transaction.begin();
+
+        Order order = new Order();
+        order.setUuid(UUID.randomUUID().toString());
+        order.setOrderStatus(OrderStatus.OPENED);
+        order.setMemo("---");
+        order.setOrderDatetime(LocalDateTime.now());
+
+        order.setCreatedBy("guppy.kang");
+        order.setCreatedAt(LocalDateTime.now());
+
+        entityManager.persist(order);
+
+        transaction.commit();
+
     }
 
 


### PR DESCRIPTION
`@mappedSuperClass` annotation을 사용하여 자주 사용하는 field를 묶어서 extends로 상속 받아서 사용한다. 
이렇게 사용 시 DB에 자동적으로 상속받은 부모 클래스의 field들이 함께 들어간다. 
=> 실습에서 created_at &created_by를 부모 클래스에 정의한 후 Order class에서 BaseEntity를 상속 받게 작성하였다.    
![image](https://user-images.githubusercontent.com/110768149/218676671-c1827194-366c-4a29-861e-e99107ea49fd.png)
