### PR TITLE
Proxy - Lazy & Eager

### DIFF
--- a/src/main/java/com/project/jpaproject/domain/order/Member.java
+++ b/src/main/java/com/project/jpaproject/domain/order/Member.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Setter
 public class Member extends BaseEntity {
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
     @Column(name = "name", nullable = false, length = 30)

--- a/src/test/java/com/project/jpaproject/domain/order/ProxyTest.java
+++ b/src/test/java/com/project/jpaproject/domain/order/ProxyTest.java
@@ -1,0 +1,96 @@
+package com.project.jpaproject.domain.order;
+
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityTransaction;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static com.project.jpaproject.domain.order.OrderStatus.OPENED;
+
+@Slf4j
+@SpringBootTest
+public class ProxyTest {
+
+    @Autowired
+    EntityManagerFactory emf;
+
+    private final String uuid = UUID.randomUUID().toString();
+
+    @BeforeEach
+    void setUp() {
+        EntityManager entityManager = emf.createEntityManager();
+        EntityTransaction transaction = entityManager.getTransaction();
+        transaction.begin();
+
+        // 주문 엔티티
+        Order order = new Order();
+        order.setUuid(uuid);
+        order.setMemo("please... push the bell");
+        order.setOrderDatetime(LocalDateTime.now());
+        order.setOrderStatus(OPENED);
+
+        entityManager.persist(order);
+
+        // 회원 엔티티
+        Member member = new Member();
+        member.setName("kanghonggu");
+        member.setNickName("guppy.kang");
+        member.setAge(33);
+        member.setAddress("서울시 동작구만 움직이면쏜다.");
+        member.setDescription("KDT 화이팅");
+
+        member.addOrder(order); // 연관관계 편의 메소드 사용
+        entityManager.persist(member);
+        transaction.commit();
+    }
+
+
+    @Test
+    void proxy() {
+//        EntityManager entityManager = emf.createEntityManager();
+//
+//        // 회원 조회 -> 회원의 주문 까지 조회
+//        Member findMember = entityManager.find (Member.class, 1L);
+//
+//        log.info("orders is loaded : {}", entityManager.getEntityManagerFactory()
+//                .getPersistenceUnitUtil().isLoaded(findMember.getOrders()));
+//
+//        log.info("-------");
+//        log.info("{}", findMember.getOrders().get(0).getMemo());
+//        log.info("orders is loaded : {}", entityManager.getEntityManagerFactory()
+//                .getPersistenceUnitUtil().isLoaded(findMember.getOrders()));
+
+        EntityManager entityManager = emf.createEntityManager();
+        Order order = entityManager.find(Order.class, uuid);
+
+        Member member = order.getMember();
+        log.info("MEMBER USE BEFORE IS-LOADED: {}", emf.getPersistenceUnitUtil().isLoaded(member));   //member객체는 Lazy: Proxy객체, EAGER:
+        String nickName = member.getNickName();  //member객체 사용
+        log.info("MEMBER USE AFTER IS-LOADED: {}", emf.getPersistenceUnitUtil().isLoaded(member));   //member 객체 Lazy: entity
+
+    }
+
+
+//    @Test
+//    void orphan() {
+//        EntityManager entityManager = emf.createEntityManager();
+//
+//        // 회원 조회 -> 회원의 주문 까지 조회
+//        Member findMember = entityManager.find(Member.class, 1L);
+//        findMember.getOrders().remove(0);
+//
+//        EntityTransaction transaction = entityManager.getTransaction();
+//
+//        transaction.begin();
+//        transaction.commit();
+//    }
+
+}


### PR DESCRIPTION
Lazy & Eager

- 프록시 객체는 **처음** 사용할 때 **한번만 초기화** 된다.
- 프록시 객체가 초기화되면, 프록시 객체를 통해서 실제 엔티티에 접근 할 수 있다.
- **초기화는 영속성 컨텍스트의 도움을 받아야 가능하다.** 따라서 준영속 상태의 프록시를 초기화하면 **LazyInitializationException** 예외가 발생한다.
**지연로딩**

엔티티를 조회할때, 연관된 엔티티를 함께 조회한다. order는 proxy객체로 채워져있다. order를 사용하거나 조회하는 경우 그제서야 영속성 컨텍스트로 DB조회해서 Entity 생성해서 반환 
![image](https://user-images.githubusercontent.com/110768149/218893590-d0697152-8638-4be3-8aa6-3b2c89a04c00.png)
    
**즉시로딩**

연관된 엔티티를 실제 사용할 때 조회한다. 한 번에 Member와 Orders를 Entity화 시켜서 DB에서 가져온다.
![image](https://user-images.githubusercontent.com/110768149/218893657-1f2aced8-5051-479b-8891-78b3baab449c.png)

코드
   
![image](https://user-images.githubusercontent.com/110768149/218893744-3ddc49bf-1af5-47b9-9164-ac428f728b07.png)
Lazy: false true
Eager: true true
