### PR TITLE
고아객체 orphan

### DIFF
--- a/src/main/java/com/project/jpaproject/domain/order/Order.java
+++ b/src/main/java/com/project/jpaproject/domain/order/Order.java
@@ -39,7 +39,7 @@ public class Order extends BaseEntity{
     @JoinColumn(name = "member_id", referencedColumnName = "id")
     private Member member;
 
-    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL) //영속성 전이 추가 +cascade
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true) //영속성 전이 추가 +cascade   //고아객체 true 같이 삭제
     private List<OrderItem> orderItems = new ArrayList<>();
 
     //연관관계 편의 메소드

--- a/src/test/java/com/project/jpaproject/domain/order/ProxyTest.java
+++ b/src/test/java/com/project/jpaproject/domain/order/ProxyTest.java
@@ -45,7 +45,7 @@ public class ProxyTest {
         // 회원 엔티티
         Member member = new Member();
         member.setName("kanghonggu");
-        member.setNickName("guppy.HA");
+        member.setNickName("guppy.HAHA");
         member.setAge(33);
         member.setAddress("서울시 동작구");
         member.setDescription("KDT 화이팅");
@@ -89,6 +89,15 @@ public class ProxyTest {
         order.addOrderItems(orderItem); //order class에서 orderItems를 cascade하여 commit 하면 영속전이를 통해 영속으로 바뀌고 쿼리가 날라간다.
 
         transaction.commit();   //flush()   //영속성 정의 X ordrItem: 쿼리 날라가지 않음
+
+        entityManager.clear();
+
+        //////////Orphan Test start
+        Order order2 = entityManager.find(Order.class, uuid);
+
+        transaction.begin();
+        order2.getOrderItems().remove(0);   //고아상태 flush 순간 RDS 에서도 삭제하겠다.   //orphan 속성 추가해야함 (ORder.class에서)
+        transaction.commit();
     }
 
 


### PR DESCRIPTION
orphan remove 속성으로 삭제 시 delete쿼리가 안 날라가는 경우를 방지   
부모 엔티티와 연관관계가 끊어진 자식 엔티티를 자동으로 삭제하는 기능 추가 